### PR TITLE
Add author og/twitter tags.

### DIFF
--- a/content/birds/jonny.rst
+++ b/content/birds/jonny.rst
@@ -7,7 +7,9 @@ adr:
 social:
   - twitter: jgerigmeyer
     github: jgerigmeyer
-facebook: jgerigmeyer
+og:
+  - facebook: jgerigmeyer
+    twitter: jgerigmeyer
 summary: |
   `Jonny Gerig Meyer`_
   is an architect of clean,

--- a/content/birds/jonny.rst
+++ b/content/birds/jonny.rst
@@ -2,11 +2,12 @@ public: yes
 bird: jonny
 role: 'co-founder and front-end lead'
 adr:
-  - city: 'Goshen'
-    state: 'IN'
+  - city: Goshen
+    state: IN
 social:
-  - twitter: 'jgerigmeyer'
-    github: 'jgerigmeyer'
+  - twitter: jgerigmeyer
+    github: jgerigmeyer
+facebook: jgerigmeyer
 summary: |
   `Jonny Gerig Meyer`_
   is an architect of clean,

--- a/templates/base.html
+++ b/templates/base.html
@@ -40,7 +40,8 @@
   <!-- Open Graph -->
   {% set image = config.image[0].src if config.image else 'oddsite.jpg' %}
   {% set image = image if '://' in image else [config.canonical_url, 'static/images/blog/', image]|join('') %}
-  <meta property="og:title" content="{{ self.title() }} | OddBird" />
+  <meta property="fb:app_id" content="1820980378150914" />
+  <meta property="og:title" content="{{ self.title() }}" />
   <meta property="og:site_name" content="OddBird" />
   <meta property="og:type" content="{% block og_type %}website{% endblock og_type %}" />
   <meta property="og:image" content="{{ image }}" />

--- a/templates/base.html
+++ b/templates/base.html
@@ -48,10 +48,10 @@
   {% if config.summary %}
     <meta property="og:description" content="{% block og_summary %}{% endblock og_summary %}" />
   {% endif %}
+  <meta name="twitter:card" content="{% block twitter_type %}summary{% endblock %}" />
+  <meta name="twitter:site" content="@oddbird" />
   {% block extra_og %}
   {% endblock extra_og %}
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:site" content="@oddbird" />
 
   <!--iOS. Delete if not required -->
   <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/templates/base.html
+++ b/templates/base.html
@@ -41,12 +41,15 @@
   {% set image = config.image[0].src if config.image else 'oddsite.jpg' %}
   {% set image = image if '://' in image else [config.canonical_url, 'static/images/blog/', image]|join('') %}
   <meta property="og:title" content="{{ self.title() }} | OddBird" />
-  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="OddBird" />
+  <meta property="og:type" content="{% block og_type %}website{% endblock og_type %}" />
   <meta property="og:image" content="{{ image }}" />
   <meta property="og:url" content="{% block og_url %}{{ config.canonical_url }}{% endblock og_url %}" />
   {% if config.summary %}
     <meta property="og:description" content="{% block og_summary %}{% endblock og_summary %}" />
   {% endif %}
+  {% block extra_og %}
+  {% endblock extra_og %}
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:site" content="@oddbird" />
 

--- a/templates/birds/utility.macros.j2
+++ b/templates/birds/utility.macros.j2
@@ -33,8 +33,8 @@
 
 {% macro get_og_author(author) -%}
   {% set page = all_pages|filter_pages('bird', 'eq', author)|get_page %}
-  {%- if page and page.config.facebook -%}
-    {{ ['https://www.facebook.com/', page.config.facebook]|join('') }}
+  {%- if page and page.config.og and page.config.og[0].facebook -%}
+    https://www.facebook.com/{{ page.config.og[0].facebook }}
   {%- else -%}
     {{ page.title or author }}
   {%- endif -%}
@@ -43,8 +43,8 @@
 
 {% macro get_og_twitter_creator(author) -%}
   {% set page = all_pages|filter_pages('bird', 'eq', author)|get_page %}
-  {%- if page and page.config.social[0].twitter -%}
-    <meta property="twitter:creator" content="@{{ page.config.social[0].twitter }}" />
+  {%- if page and page.config.og and page.config.og[0].twitter -%}
+    <meta property="twitter:creator" content="@{{ page.config.og[0].twitter }}" />
   {%- endif -%}
 {%- endmacro %}
 

--- a/templates/birds/utility.macros.j2
+++ b/templates/birds/utility.macros.j2
@@ -31,6 +31,24 @@
 {% endmacro %}
 
 
+{% macro get_og_author(author) -%}
+  {% set page = all_pages|filter_pages('bird', 'eq', author)|get_page %}
+  {%- if page and page.config.facebook -%}
+    {{ ['https://www.facebook.com/', page.config.facebook]|join('') }}
+  {%- else -%}
+    {{ page.title or author }}
+  {%- endif -%}
+{%- endmacro %}
+
+
+{% macro get_og_twitter_creator(author) -%}
+  {% set page = all_pages|filter_pages('bird', 'eq', author)|get_page %}
+  {%- if page and page.config.social[0].twitter -%}
+    <meta property="twitter:creator" content="@{{ page.config.social[0].twitter }}" />
+  {%- endif -%}
+{%- endmacro %}
+
+
 {% macro name_link(author, page=none, fallback=none) %}
   {# Get the birds's page #}
   {% set page = page if page else all_pages|filter_pages('bird', 'eq', author)|get_page %}

--- a/templates/rst_display.html
+++ b/templates/rst_display.html
@@ -9,6 +9,7 @@
 {% block og_type %}{{ 'article' if ctx.pub_date else 'website' }}{% endblock %}
 {% block og_url %}{{ get_full_canonical_url(ctx.builder, slug=ctx.slug) }}{% endblock %}
 {% block og_summary %}{{ ctx.render_summary()|striptags }}{% endblock %}
+{% block twitter_type %}{{ 'summary_large_image' if ctx.config.image and ctx.config.image[0].src else 'summary' }}{% endblock %}
 {% block extra_og %}
   {% if ctx.pub_date %}
     <meta property="article:published_time" content="{{ ctx.pub_date.isoformat() }}" />

--- a/templates/rst_display.html
+++ b/templates/rst_display.html
@@ -6,8 +6,23 @@
 
 {% block title %}{{ rst.title }}{% endblock %}
 
+{% block og_type %}{{ 'article' if ctx.pub_date else 'website' }}{% endblock %}
 {% block og_url %}{{ get_full_canonical_url(ctx.builder, slug=ctx.slug) }}{% endblock %}
 {% block og_summary %}{{ ctx.render_summary()|striptags }}{% endblock %}
+{% block extra_og %}
+  {% if ctx.pub_date %}
+    <meta property="article:published_time" content="{{ ctx.pub_date.isoformat() }}" />
+    {% if ctx.author %}
+      <meta property="article:author" content="{{ birds.get_og_author(ctx.author) }}" />
+      {{ birds.get_og_twitter_creator(ctx.author) }}
+    {% endif %}
+    {% if ctx.tags %}
+      {% for tag in ctx.tags %}
+        <meta property="article:tag" content="{{ tag }}" />
+      {% endfor %}
+    {% endif %}
+  {% endif %}
+{% endblock %}
 
 {% block body %}
   {%- if not config.hide_title %}


### PR DESCRIPTION
This PR adds `article:published_time`, `article:author`, `article:tag`, and `twitter:creator` tags to blog posts only.

The `article:author` can be a name or a link to the author's Facebook page. If people want that, they should add their Facebook ID to their respective birds/ page, e.g. `facebook: jgerigmeyer`.