### PR TITLE
[form-sizes] Match input/small-btn sizes

### DIFF
--- a/static/sass/patterns/_forms.scss
+++ b/static/sass/patterns/_forms.scss
@@ -3,7 +3,7 @@
 
 [data-form-field] {
   display: block;
-  margin-bottom: 0.5rem;
+  margin-bottom: size('shim');
 }
 
 .form-label {
@@ -14,7 +14,8 @@
 [data-input-type='textarea'] {
   border: 1px solid color('border');
   display: block;
-  padding: 0.25rem 0.5rem;
+  font-size: size('small');
+  padding: size('half-shim');
   width: 100%;
 }
 


### PR DESCRIPTION
## Link to Trello Card
https://trello.com/c/xQ93Lx8w/11-i-want-an-email-newsletter
https://trello.com/c/oXQoQ1CO/10-2-i-want-newsletter-signup-on-oddsite

## Description
I adjusted the default sizes for form inputs, so that a small button and default input would align properly when in-line.

## Impacted areas of website
- `/2019/04/09/vueconf/` has an in-page inline form
- the footer has a running inline form
- this touches other form inputs, such as `/contact/`

* * *

## Reviewer tasks:

https://deploy-preview-316--oddsite.netlify.com/

- [x] Reviewed functionality (locally or on Netlify)
- [x] Reviewed code
