### PR TITLE
removed 5K cost from research and concepting

### DIFF
--- a/content/services/planning.rst
+++ b/content/services/planning.rst
@@ -110,8 +110,8 @@ Research & Concepting
 Project Discovery & Planning with Development Estimate
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``$5000`` – everything you need to start development
-++++++++++++++++++++++++++++++++++++++++++++++++++++
+everything you need to start development
+++++++++++++++++++++++++++++++++++++++++
 
 Have you raised your first round of funding and need a design & development
 partner to help make your brilliant idea a reality? Or do you need help


### PR DESCRIPTION
## Description
I am proposing removing the $5,000 flat fee amount from the R&C page. We keep creating custom versions of R&C anyway. We also have yet to streamline R&C enough to come in at or under $5K when we do all the tasks in the published list. Maybe we can publish a flat fee in the future, but perhaps we should wait until we're really confident in that number.

## Impacted areas of website
http://oddbird.net/services/planning/